### PR TITLE
Test load env properties from user provided path

### DIFF
--- a/src/main/java/io/sysr/springcontext/env/EnvContextLoader.java
+++ b/src/main/java/io/sysr/springcontext/env/EnvContextLoader.java
@@ -39,7 +39,6 @@ public class EnvContextLoader {
     public EnvContextLoader() {
         super();
         logger.trace("Spring context dot env loader initiated");
-
     }
 
     public Properties getLoadedProperties() {
@@ -67,8 +66,8 @@ public class EnvContextLoader {
                 StandardCharsets.UTF_8)) {
             Properties props = new Properties();
             props.load(reader);
-            String directoryPath = Stream.of("BASE_DIR", "base_dir")
-                    .map(props::getProperty)
+            String directoryPath = Stream.of("BASE_DIR")
+                    .map(key -> props.getProperty(key.toUpperCase()))
                     .filter(Objects::nonNull)
                     .findFirst()
                     .orElse(null);

--- a/src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java
+++ b/src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java
@@ -8,8 +8,10 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Properties;
 import java.lang.reflect.InvocationTargetException;
 
 import org.junit.jupiter.api.AfterEach;
@@ -18,6 +20,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class EnvContextLoaderTest {
+    private static final String ENV_PROPERTIES_FILE_NAME = "env.properties";
+
     @TempDir
     Path tempDir;
 
@@ -41,7 +45,7 @@ class EnvContextLoaderTest {
         // Create the resources directory and env.properties file
         Path resourcesDirPath = root.resolve("resources");
         Files.createDirectories(resourcesDirPath);
-        Path envFile = resourcesDirPath.resolve("env.properties");
+        Path envFile = resourcesDirPath.resolve(ENV_PROPERTIES_FILE_NAME);
         Files.createFile(envFile);
 
         try {
@@ -50,7 +54,7 @@ class EnvContextLoaderTest {
             method.setAccessible(true);
             String path = (String) method.invoke(envContextLoader);
 
-            assertThat(path).isNotNull().endsWith("env.properties");
+            assertThat(path).isNotNull().endsWith(ENV_PROPERTIES_FILE_NAME);
             assertThat(new File(path)).exists().isFile();
             assertThat(path).isEqualTo(envFile.toString());
         } finally {
@@ -68,7 +72,7 @@ class EnvContextLoaderTest {
 
         // Ensure the env.properties file does not exist
         Path resourcesDirPath = root.resolve("resources");
-        Path envFile = resourcesDirPath.resolve("env.properties");
+        Path envFile = resourcesDirPath.resolve(ENV_PROPERTIES_FILE_NAME);
 
         if (Files.exists(envFile)) {
             fail("Test failed because env.properties file exists when it should not.");
@@ -80,5 +84,62 @@ class EnvContextLoaderTest {
         String path = (String) method.invoke(envContextLoader);
 
         assertThat(path).isNull();
+    }
+
+    @Test
+    void whenUserProvidedValidPropertiesFilePath_thenTheFileContentMustBeLoadedSuccessfully() throws URISyntaxException,
+            IOException, NoSuchMethodException, SecurityException, IllegalAccessException, InvocationTargetException {
+        Path userDir = tempDir.resolve("config");
+        Files.createDirectories(userDir);
+        Path filePath = userDir.resolve("env");
+        Files.createFile(filePath);
+        Files.writeString(filePath, "KEY=VALUE", StandardCharsets.UTF_8);
+
+        // Get the root URL from the class loader
+        URL url = EnvContextLoader.class.getClassLoader().getResource("");
+        Path root = Path.of(url.toURI());
+
+        // Create the resources directory and env.properties file
+        Path resourcesDirPath = root.resolve("resources");
+        Files.createDirectories(resourcesDirPath);
+        Path envFile = resourcesDirPath.resolve(ENV_PROPERTIES_FILE_NAME);
+        Files.createFile(envFile);
+        Files.writeString(envFile, "BASE_DIR=%s%nFILE_NAME=%s%n".formatted(userDir.toString(), filePath.toString()));
+
+        try {
+            EnvContextLoader envContextLoader = new EnvContextLoader();
+            Method findEnvPropertiesFileMethod = EnvContextLoader.class.getDeclaredMethod("findEnvPropertiesFile");
+
+            findEnvPropertiesFileMethod.setAccessible(true);
+            String path = (String) findEnvPropertiesFileMethod.invoke(envContextLoader);
+
+            assertThat(path).isNotNull().endsWith(ENV_PROPERTIES_FILE_NAME);
+            assertThat(new File(path)).exists().isFile();
+            assertThat(path).isEqualTo(envFile.toString());
+
+            // Load file from user dir
+            Method loadFromUserDirMethod = EnvContextLoader.class.getDeclaredMethod(
+                    "loadFromUserProvidedDirectory",
+                    String.class);
+
+            loadFromUserDirMethod.setAccessible(true);
+            loadFromUserDirMethod.invoke(envContextLoader, path);
+
+            Properties props = envContextLoader.getLoadedProperties();
+            assertThat(props)
+                    .isNotNull()
+                    .isNotEmpty()
+                    .hasSize(1);
+
+            assertThat(props.stringPropertyNames())
+                    .contains("KEY");
+
+            assertThat(props.getProperty("KEY"))
+                    .isEqualTo("VALUE");
+
+        } finally {
+            Files.deleteIfExists(envFile);
+            Files.deleteIfExists(resourcesDirPath);
+        }
     }
 }


### PR DESCRIPTION
### test: Add unit test to verify loading properties from user-provided directory

This commit adds a unit test to ensure that the `EnvContextLoader`
can successfully load properties from a user-provided directory
when a valid properties file path is supplied.

 - Added `whenUserProvidedValidPropertiesFilePath_thenTheFileContentMustBeLoadedSuccessfully`
test method in `EnvContextLoaderTest.java`.

 - The test creates a temporary user directory and writes a sample
   properties file (`env`) with a key-value pair (`KEY=VALUE`).

 - It configures the `env.properties` file with the `BASE_DIR` and
   `FILE_NAME` pointing to the user directory and properties file,
   respectively.

 - The test invokes the private `loadFromUserProvidedDirectory`
   method via reflection and verifies that the properties are
   loaded correctly.

 - Asserts that the loaded properties contain the expected
   key-value pair.

This enhancement improves test coverage for loading properties
from user-specified directories and ensures the reliability of
the `EnvContextLoader` under these conditions.

Affected File:
 - src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java