### PR TITLE
conf: Update the sonar task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 # Log file
 *.log
 
-# Package Files #   
+# Package Files #
 *.jar
 !gradle/wrapper/gradle-wrapper.jar
 
@@ -14,6 +14,9 @@ replay_pid*
 
 # Ignore Gradle project-specific cache directory
 .gradle
+
+# Ignore gradle.properties if it has secrets
+gradle.properties
 
 # Ignore Gradle build output directory
 build

--- a/build.gradle
+++ b/build.gradle
@@ -67,9 +67,10 @@ jacocoTestReport {
 
 sonar {
     properties {
-        property "sonar.projectKey", "sysrio_springcontext-env"
-        property "sonar.organization", "sysrio"
-        property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.projectKey", prop("sonar_project_key")
+        property "sonar.organization", prop("sonar_organization")
+        property "sonar.token", prop("sonar_token")
+        property "sonar.host.url", prop("sonar_host_url", "https://sonarcloud.io")
     }
 }
 
@@ -134,4 +135,15 @@ jreleaser {
     }
     gitRootSearch = true
     strict = true
+}
+
+def prop(name, defaultValue = null) {
+    def value = project.findProperty(name) ?: System.getenv(name.toUpperCase()) ?: defaultValue
+    if(value == null) {
+        GradleException(
+            """
+            Property '${name}' is not set. Please specify it in gradle.properties or as an environment variable.
+            """)
+    }
+    return value
 }


### PR DESCRIPTION
Updated the sonarQube task to read the configuration properties from the gradle.properties or from the system's environment.

This update ensures that sonarqube configurations are generalized and the contributors can easily configure their respective folks and test their sources and updates locally before uploading their patches.

NOTE:
 - The gradle.properties file is added to the .gitignore file so that any secrets added to it are not accidentally pushed with the patches.

Affected Files:
 - build.gradle
 - .gitignore