### PR TITLE
fix: Fix test failure on Windows 

### DIFF
--- a/src/main/java/io/sysr/springcontext/env/EnvContextLoader.java
+++ b/src/main/java/io/sysr/springcontext/env/EnvContextLoader.java
@@ -76,13 +76,14 @@ public class EnvContextLoader {
                 List<String> fileNameKeys = props.stringPropertyNames()
                         .stream().filter(key -> key.toUpperCase().startsWith("FILE"))
                         .toList();
-
+                logger.info(directoryPath);
                 for (String fileNameKey : fileNameKeys) {
                     String fileName = props.getProperty(fileNameKey);
                     Path path = Path.of(directoryPath).normalize().resolve(fileName).normalize();
                     File file = path.toFile();
+                    logger.info("{}", path);
                     if (file.exists() && file.isFile()) {
-                        parse(path);
+                        parse(path.toAbsolutePath());
                         logger.info("Successfully loaded properties from {}", path.toAbsolutePath());
                     }
                 }

--- a/src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java
+++ b/src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java
@@ -103,11 +103,9 @@ class EnvContextLoaderTest {
         Path resourcesDirPath = root.resolve("resources");
         Files.createDirectories(resourcesDirPath);
         Path envFile = resourcesDirPath.resolve(ENV_PROPERTIES_CONFIG_FILE_NAME);
+        String baseDir = userDir.toAbsolutePath().toString().replace("\\", "/");
         Files.createFile(envFile);
-        Files.writeString(envFile,
-                "BASE_DIR=%s%nFILE_NAME=%s%n".formatted(
-                        userDir.toAbsolutePath().toString(),
-                        filePath.getFileName().toString()));
+        Files.writeString(envFile, "BASE_DIR=%s%nFILE_NAME=%s%n".formatted(baseDir, filePath.getFileName().toString()));
 
         try {
             EnvContextLoader envContextLoader = new EnvContextLoader();


### PR DESCRIPTION
- Update EnvContextLoaderTest to handle Windows file paths correctly.

- Modify the test to replace backslashes with forward slashes when writing the BASE_DIR property.

- This prevents backslashes from being misinterpreted as escape characters in Java properties files, ensuring the Properties object is loaded successfully on Windows.

The test was failing on Windows because backslashes (\) in file paths were being interpreted as escape characters in the Java properties file. This caused the Properties class to misparse the BASE_DIR property, resulting in an empty Properties object.

Affected File:
 - src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java