### PR TITLE
Fix test failure caused by wrong file parsing

### DIFF
--- a/src/main/java/io/sysr/springcontext/env/EnvContextLoader.java
+++ b/src/main/java/io/sysr/springcontext/env/EnvContextLoader.java
@@ -61,8 +61,9 @@ public class EnvContextLoader {
         }
     }
 
-    private void loadFromUserProvidedDirectory(String filePath) {
-        try (InputStreamReader reader = new InputStreamReader(Files.newInputStream(Path.of(filePath)),
+    private void loadFromUserProvidedDirectory(String envPropertiesFilePath) {
+        try (InputStreamReader reader = new InputStreamReader(Files.newInputStream(Path.of(
+                envPropertiesFilePath)),
                 StandardCharsets.UTF_8)) {
             Properties props = new Properties();
             props.load(reader);
@@ -87,7 +88,7 @@ public class EnvContextLoader {
                     }
                 }
             } else {
-                logger.warn("Neither BASE_DIR nor base_dir property found in the properties file - {}", filePath);
+                logger.warn("BASE_DIR not found in the properties file - {}", envPropertiesFilePath);
             }
         } catch (Exception e) {
             throw new EnvContextLoaderException(e.getLocalizedMessage(), e);

--- a/src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java
+++ b/src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java
@@ -106,7 +106,7 @@ class EnvContextLoaderTest {
         Files.createFile(envFile);
         Files.writeString(envFile,
                 "BASE_DIR=%s%nFILE_NAME=%s%n".formatted(
-                        userDir.toAbsolutePath().toString(),
+                        userDir.toString().replace("\\", "\\\\"),
                         filePath.getFileName().toString()));
 
         try {


### PR DESCRIPTION
Update EnvContextLoaderTest to handle Windows file paths correctly. This update modifies the test to replace backslashes `\\` with double backlashes `\\\\` when writing the BASE_DIR property. This prevents backslashes from being misinterpreted as escape characters in Java properties files, ensuring the Properties object is loaded successfully on Windows.

Affected File:
 - src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java