### PR TITLE
Add test for loading properties from default root directory

### DIFF
--- a/src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java
+++ b/src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java
@@ -219,4 +219,21 @@ class EnvContextLoaderTest {
             assertThat(props.getProperty("KEY"))
                     .isEqualTo("VALUE");
     }
+
+    @Test
+    void whenDefaultRootLoaderIsTriggeredAndEnvFileIsNotAvailable_thenNothingIsLoaded() throws
+                URISyntaxException, IOException, NoSuchMethodException, SecurityException, IllegalAccessException,
+                InvocationTargetException {
+        Path rootPath = Files.createDirectories(tempDir.resolve("springcontext-env"));
+
+        EnvContextLoader envContextLoader = new EnvContextLoader();
+        Method loadFromDefaultRootDir = EnvContextLoader.class.getDeclaredMethod("loadFromDefaultRootDirectory", String.class);
+        loadFromDefaultRootDir.setAccessible(true);
+        loadFromDefaultRootDir.invoke(envContextLoader, rootPath.toAbsolutePath().toString());
+
+        Properties props = envContextLoader.getLoadedProperties();
+            assertThat(props)
+                    .isNotNull()
+                    .isEmpty();
+    }
 }

--- a/src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java
+++ b/src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java
@@ -193,4 +193,30 @@ class EnvContextLoaderTest {
             Files.deleteIfExists(resourcesDirPath);
         }
     }
+
+    @Test
+    void whenDefaultRootLoaderIsTriggeredAndEnvFileIsAvailable_thenTheFileContentMustBeLoadedSuccessfully() throws
+                URISyntaxException, IOException, NoSuchMethodException, SecurityException, IllegalAccessException,
+                InvocationTargetException {
+        Path rootPath = Files.createDirectories(tempDir.resolve("springcontext-env"));
+        Path envFile = Files.createFile(rootPath.resolve(".env"));
+        Files.writeString(envFile,"KEY=VALUE", StandardCharsets.UTF_8);
+
+        EnvContextLoader envContextLoader = new EnvContextLoader();
+        Method loadFromDefaultRootDir = EnvContextLoader.class.getDeclaredMethod("loadFromDefaultRootDirectory", String.class);
+        loadFromDefaultRootDir.setAccessible(true);
+        loadFromDefaultRootDir.invoke(envContextLoader, rootPath.toAbsolutePath().toString());
+
+        Properties props = envContextLoader.getLoadedProperties();
+            assertThat(props)
+                    .isNotNull()
+                    .isNotEmpty()
+                    .hasSize(1);
+
+            assertThat(props.stringPropertyNames())
+                    .contains("KEY");
+
+            assertThat(props.getProperty("KEY"))
+                    .isEqualTo("VALUE");
+    }
 }


### PR DESCRIPTION
Added a unit test to verify that the EnvContextLoader correctly loads properties from an `.env*` file located in the default root directory. The default root dir in this context is `user.dir` as evaluated by `Java virtual machine (JVM)`.

The test whenDefaultRootLoaderIsTriggeredAndEnvFileIsAvailable_thenTheFileContentMustBeLoadedSuccessfully performs the following steps:
 - Creates a temporary directory and an .env file containing KEY=VALUE.
 - Uses reflection to invoke the private loadFromDefaultRootDirectory method on an EnvContextLoader instance.
 - Asserts that the properties are loaded correctly

This test ensures that the EnvContextLoader can load properties from
 the default root directory when an .env file is present.

Affected File:
 -  src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java