### PR TITLE
Remove unused Exception signatures

### DIFF
--- a/src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java
+++ b/src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java
@@ -196,7 +196,7 @@ class EnvContextLoaderTest {
 
     @Test
     void whenDefaultRootLoaderIsTriggeredAndEnvFileIsAvailable_thenTheFileContentMustBeLoadedSuccessfully() throws
-                URISyntaxException, IOException, NoSuchMethodException, SecurityException, IllegalAccessException,
+                IOException, NoSuchMethodException, SecurityException, IllegalAccessException,
                 InvocationTargetException {
         Path rootPath = Files.createDirectories(tempDir.resolve("springcontext-env"));
         Path envFile = Files.createFile(rootPath.resolve(".env"));
@@ -222,7 +222,7 @@ class EnvContextLoaderTest {
 
     @Test
     void whenDefaultRootLoaderIsTriggeredAndEnvFileIsNotAvailable_thenNothingIsLoaded() throws
-                URISyntaxException, IOException, NoSuchMethodException, SecurityException, IllegalAccessException,
+                IOException, NoSuchMethodException, SecurityException, IllegalAccessException,
                 InvocationTargetException {
         Path rootPath = Files.createDirectories(tempDir.resolve("springcontext-env"));
 


### PR DESCRIPTION
Remoded URISyntaxException from the unit tests that did not use them. The following tests did not use them, even though they were thrown:
 - whenDefaultRootLoaderIsTriggeredAndEnvFileIsAvailable_thenTheFileContentMustBeLoadedSuccessfully()
 - whenDefaultRootLoaderIsTriggeredAndEnvFileIsNotAvailable_thenNothingIsLoaded()