### PR TITLE
SpringContextEnvironmentPostProcessor Implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies { 
-    implementation libs.springContext
+    implementation libs.springBootCore
     implementation libs.slf4jApi
     testImplementation libs.slf4jSimple
     testImplementation libs.junitJupiterEngine

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,11 @@ spring = "6.2.1"
 slf4j = "2.0.16"
 junitJupiter = "5.11.3"
 assertj = "3.26.3"
+springBoot = "3.4.1"
+
 
 [libraries]
-springContext = {module = "org.springframework:spring-context", version.ref = "spring" }
+springBootCore = {module = "org.springframework.boot:spring-boot", version.ref = "springBoot" }
 
 junitJupiterApi = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junitJupiter" }
 

--- a/src/main/java/io/sysr/springcontext/env/SpringContextEnvironmentPostProcessor.java
+++ b/src/main/java/io/sysr/springcontext/env/SpringContextEnvironmentPostProcessor.java
@@ -1,0 +1,26 @@
+package io.sysr.springcontext.env;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.PropertySource;
+
+public class SpringContextEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        EnvContextLoader loader = new EnvContextLoader();
+        loader.load();
+
+        PropertySource<?> propertySource = new PropertiesPropertySource("springContextDotEnv",
+                loader.getLoadedProperties());
+        environment.getPropertySources().addLast(propertySource);
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+}

--- a/src/main/java/io/sysr/springcontext/env/exception/EnvContextLoaderException.java
+++ b/src/main/java/io/sysr/springcontext/env/exception/EnvContextLoaderException.java
@@ -1,7 +1,5 @@
 package io.sysr.springcontext.env.exception;
 
-import org.springframework.lang.NonNull;
-
 /**
  * Exception thrown when there is an error loading the environment variables
  * from a dotenv file in a Spring application. This exception extends
@@ -39,7 +37,7 @@ public class EnvContextLoaderException extends RuntimeException {
      * @param message the detail message, saved for later retrieval by the
      *                {@link #getMessage()} method.
      */
-    public EnvContextLoaderException(@NonNull String message) {
+    public EnvContextLoaderException(String message) {
         super(message);
     }
 
@@ -52,7 +50,7 @@ public class EnvContextLoaderException extends RuntimeException {
      * @param cause   the underlying cause of the exception,
      *                saved for later retrieval by the {@link #getCause()} method.
      */
-    public EnvContextLoaderException(@NonNull String message, Throwable cause) {
+    public EnvContextLoaderException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/src/test/java/io/sysr/springcontext/env/SpringContextEnvironmentPostProcessorTest.java
+++ b/src/test/java/io/sysr/springcontext/env/SpringContextEnvironmentPostProcessorTest.java
@@ -1,0 +1,59 @@
+package io.sysr.springcontext.env;
+
+import org.springframework.boot.SpringApplication;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.PropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+class SpringContextEnvironmentPostProcessorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tempDir = Files.createTempDirectory("springcontext-env");
+        System.setProperty("user.dir", tempDir.toAbsolutePath().toString());
+    }
+
+    @Test
+    void whenSpringContextEnvironmentPostProcessorIsInvoked_thenAvailableDotEnvFilesAreLoaded() throws IOException {
+        String content = "KEY1=VALUE1\nKEY2=VALUE2\nKEY3=VALUE3";
+        Files.writeString(tempDir.resolve(".env"), content, StandardCharsets.UTF_8);
+
+        // Create a mock SpringApplication
+        SpringApplication application = new SpringApplication();
+
+        ConfigurableEnvironment environment = new StandardEnvironment();
+
+        EnvironmentPostProcessor postProcessor = new SpringContextEnvironmentPostProcessor();
+
+        postProcessor.postProcessEnvironment(environment, application);
+
+        PropertySource<?> propertySources = environment.getPropertySources().get("springContextDotEnv");
+
+        assertThat(propertySources).isNotNull();
+
+        @SuppressWarnings("null")
+        Properties props = (Properties) propertySources.getSource();
+        assertThat(props).isNotNull()
+                .hasFieldOrProperty("KEY1")
+                .hasFieldOrProperty("KEY2")
+                .hasFieldOrProperty("KEY3")
+                .hasFieldOrPropertyWithValue("KEY1", "VALUE1")
+                .hasFieldOrPropertyWithValue("KEY2", "VALUE2")
+                .hasFieldOrPropertyWithValue("KEY3", "VALUE3");
+    }
+}


### PR DESCRIPTION
Implemented `SpringContextEnvironmentPostProcessor` to load properties
into the Spring Environment from a custom `EnvContextLoader`.

The processor adds a `PropertiesPropertySource` named
`springContextDotEnv` to the environment. The implementation ensures
that the properties are available with the highest precedence by
intergrating `Ordered` funcitionality and setting the order to
`Ordered.HIGHEST_PRECEDENCE`.

Unit Test is added in `SpringContextEnvironmentPostProcessorTest` to
verify the behavior of the `EnvironmentPostProcessor`. The test verifies
that the `postProcessEnvironment` method correctly adds the
`springContextDotEnv` property source.

Created Files:
-
src/main/java/io/sysr/springcontext/env/SpringContextEnvironmentPostProcessor.java
-
src/test/java/io/sysr/springcontext/env/SpringContextEnvironmentPostProcessorTest.java