### PR TITLE
Integrate spring-boot autoconfiguration

### DIFF
--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+# Environment Post Processors
+org.springframework.boot.env.EnvironmentPostProcessor=\
+io.sysr.springcontext.env.SpringContextEnvironmentPostProcessor

--- a/src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java
+++ b/src/test/java/io/sysr/springcontext/env/EnvContextLoaderTest.java
@@ -64,7 +64,6 @@ class EnvContextLoaderTest {
                         assertThat(path).isEqualTo(envFile.toString());
                 } finally {
                         Files.deleteIfExists(envFile);
-                        Files.deleteIfExists(resourcesDirPath);
                 }
         }
 
@@ -142,7 +141,6 @@ class EnvContextLoaderTest {
 
                 } finally {
                         Files.deleteIfExists(envFile);
-                        Files.deleteIfExists(resourcesDirPath);
                 }
         }
 
@@ -188,7 +186,6 @@ class EnvContextLoaderTest {
 
                 } finally {
                         Files.deleteIfExists(envFile);
-                        Files.deleteIfExists(resourcesDirPath);
                 }
         }
 


### PR DESCRIPTION
Added spring.factories to ensure that spring boot autonconfiguration automatically picks up this EnvContextLoder whenever it is in the classpath.

Affected File:
 - src/main/resources/META-INF/spring.factories