### PR TITLE
fix: Correct ENV_DIR_PATH parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,28 +17,21 @@ There are several ways to tell the library where to look for your `.env` files:
    - If you don't specify the actual `.env` files to load, the library will, by default, load all the available files in the provided directory that start with `.env`.
    - If the filenames to be used are specified in `dotenv.properties`, then only those files will be loaded. In this case, you can name your `env` files any name you want; they don't have to be prefixed with `.env`.
 
-   **Example `dotenv.properties` file content**
+    - **Example `dotenv.properties` file content**
+      - Windows
+        ```properties
+        ENV_DIR_PATH=L:\\Lab\\apps\\configurations
+        FILE_TEST=test.config
+        FILE_PROD=prod
+        ```
+        -  **`NOTE`**: It is very important to use `\\` when defining paths on **Windows** Environment.  Otherwise you will get **`NoSuchFileException`** Error.
 
-   ```properties
-   ENV_DIR_PATH=L:\Lab\apps\config
-   FILE_1=test.config
-   FILE_2=prod
-   ```
-
-   **OR**
-
-   ```properties
-   ENV_DIR_PATH=L:\Lab\apps\config
-   FILE_A=test.config
-   FILE_B=prod
-   ```
-
-   **OR**
-
-   ```properties
-   ENV_DIR_PATH=L:\Lab\apps\config
-   FILE_NAME=.env-dev
-   ```
+      - Unix
+        ```properties
+        ENV_DIR_PATH=/home/var/configurations
+        FILE_TEST=test.config
+        FILE_PROD=prod
+        ```
 
    - Remember that file name in the `dotenv.properties` must start with **`FILE_`** followed by any letter or names you like. The variable `ENV_DIR_PATH` is case sensitive in UNIX. We recommend you maintain the uppercasing format.
 
@@ -51,12 +44,13 @@ There are several ways to tell the library where to look for your `.env` files:
    - **Examples**
      - Unix:
        ```properties
-       export ENV_DIR_PATH=/home/var/config
+       export ENV_DIR_PATH=/home/var/configurations
        ```
      - Windows:
        ```properties
-       SET ENV_DIR_PATH=L:\Lab\apps\config
+       SET ENV_DIR_PATH=L:\\Lab\\apps\\configurations
        ```
+        - **`NOTE`**: It is very important to use `\\` when defining paths on **Windows** Environment.  Otherwise you will get **`NoSuchFileException`** Error.
 
 3. **Add .env files in the project root directory**.
 

--- a/src/main/java/io/sysr/springcontext/env/EnvContextLoader.java
+++ b/src/main/java/io/sysr/springcontext/env/EnvContextLoader.java
@@ -78,7 +78,7 @@ public class EnvContextLoader {
      * The directory path where the environment files are located.
      */
     private String ENV_DIR_PATH;
-    private static final Pattern ENV_FILE_NAME_PATTERN = Pattern.compile("^\\.env\\.?\\w*$");
+    private static final Pattern ENV_FILE_NAME_PATTERN = Pattern.compile("^\\.env\\.?-?\\w*$");
     private static final Pattern VARIABLE_PATTERN_MATCHER = Pattern.compile("\\$\\{([^}]+)}");
     private static final Pattern VARIABLE_NAME_PATTERN = Pattern.compile("^[A-Za-z_][A-Za-z0-9_-]*$");
     private static final Pattern BAD_VARIABLE_PATTERN_MATCHER = Pattern.compile("\\$\\{\\s*\\}$|\\$\\{[^}]*$");
@@ -123,6 +123,7 @@ public class EnvContextLoader {
                 setEnvFilesToLoad(dotenvPropertiesPath);
                 // Load from the ENV_DIR_PATH specifired in the dotenv.properties file
                 if (Objects.nonNull(ENV_DIR_PATH) && !ENV_DIR_PATH.isBlank()) {
+                    ENV_DIR_PATH = ENV_DIR_PATH.replace("\\", "\\\\");
                     loadEnvFilesFromDirectory();
                     return;
                 }
@@ -158,14 +159,15 @@ public class EnvContextLoader {
             for (Path path : directoryStream) {
                 File file = path.toFile();
                 if (envFilesToLoad.isEmpty()) {
+                    logger.info(file.getAbsolutePath());
                     if (file.isFile() && file.getName().matches(ENV_FILE_NAME_PATTERN.pattern())) {
                         parse(path.normalize());
-                        logger.info("Successfully loaded properties from {}", path.toAbsolutePath());
+                        logger.info("Successfully loaded properties from {}", file.getName());
                     }
                 } else {
                     if (file.isFile() && envFilesToLoad.contains(file.getName())) {
                         parse(path.normalize());
-                        logger.info("Successfully loaded properties from {}", path.toAbsolutePath());
+                        logger.info("Successfully loaded properties from {}", file.getName());
                     }
                 }
 
@@ -309,10 +311,10 @@ public class EnvContextLoader {
     }
 
     /**
-     * Searches for the <code>env.properties</code> file within the classpath
+     * Searches for the <code>dotenv.properties</code> file within the classpath
      * resources.
      *
-     * @return The path to the <code>env.properties</code> file if found, or
+     * @return The path to the <code>dotenv.properties</code> file if found, or
      *         {@code null} if not found.
      * @throws URISyntaxException        If the resource URL syntax is incorrect.
      * @throws IOException               If an I/O error occurs accessing the file


### PR DESCRIPTION
Corrected the parsing of a the `ENV_DIR_PATH` when provided as a System variable or provided in the `dotenv.properties` file.